### PR TITLE
Fix CI: installer ruff/mypy avant utilisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.13" }
-      - name: Install backend (editable)
+        with:
+          python-version: "3.13"
+          cache: "pip"
+      - name: Install backend (editable) + dev tools
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install -e backend
+          python -m pip install ruff mypy pytest
       - name: Lint (ruff)
         run: ruff check backend
       - name: Types (mypy)
@@ -27,7 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
       - name: Install deps
         working-directory: frontend
         run: npm ci

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -9,27 +9,22 @@ function Fail($code, $msg){
     exit $code
 }
 
-# Python
-
 Write-Host "== PYTHON =="
 if (Test-Path "backend") {
     Push-Location backend
     python -m pip install -U pip setuptools wheel | Out-Host
     python -m pip install -e . | Out-Host
+    python -m pip install ruff mypy pytest | Out-Host
     ruff check . | Out-Host
     mypy . | Out-Host
-    if (Test-Path "..\tests") {
-        Pop-Location
-        $env:PYTHONPATH = "backend"
-        pytest -q | Out-Host
-    } else {
-        Pop-Location
-    }
+    Pop-Location
 } else {
     Fail 2 "PREREQUIS_MANQUANTS: dossier backend manquant."
 }
 
-# Node/Frontend
+Write-Host "== TESTS PYTHON =="
+$env:PYTHONPATH = "backend"
+pytest -q | Out-Host
 
 Write-Host "== FRONTEND =="
 if (Test-Path "frontend") {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@
 * Backend: pip install -e backend, ruff check backend, mypy backend, pytest (PYTHONPATH=backend)
 * Frontend: ESLint v9 (flat config: eslint.config.js), Vitest jsdom (vitest.config.ts + tests/setup.ts)
 
+## CI - Outils dev
+
+* Le job Python installe ruff, mypy et pytest avant execution.
+* En local, utilisez: `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`.
+
 ## Scripts PowerShell
 
 * PS1/test_all.ps1: lance l'ensemble des checks locaux (backend + frontend)


### PR DESCRIPTION
## Summary
- install ruff, mypy and pytest in CI job before invoking them
- update local test script to install dev tools
- document CI dev tools usage

## Testing
- `python -m pip install -U pip setuptools wheel`
- `python -m pip install -e backend`
- `python -m pip install ruff mypy pytest`
- `cd backend && ruff check .`
- `cd backend && mypy .`
- `PYTHONPATH=backend pytest`
- `cd frontend && npm ci`
- `cd frontend && npx eslint .`
- `cd frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68acfe6433f4833094c97f7986b1abe8