### PR TITLE
Fix: psycopg[binary] 3.2.x pour Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ Endpoints clefs:
 * CRUD /api/v1/availability
 * GET /api/v1/availability/conflicts?mission_id=ID
 * GET /api/v1/missions/exports/ics?range=YYYY-MM-DD,YYYY-MM-DD
+
+## Notes de compatibilite
+
+* Python 3.13: utiliser `psycopg[binary]` en version 3.2.x (>=3.2,<3.3). Les versions 3.1.x n'ont pas de roue precompilee compatible et provoquent un echec `No matching distribution`.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "pydantic-settings==2.4.0",
     "sqlalchemy==2.0.29",
     "alembic==1.13.1",
-    "psycopg[binary]==3.1.18",
+    # psycopg[binary] 3.1.x n'a pas de roue pour Python 3.13
+    "psycopg[binary]>=3.2,<3.3",
     "redis==5.0.4",
     "python-dateutil==2.9.0.post0"
 ]


### PR DESCRIPTION
## Summary
- fix backend editable install on Python 3.13 by requiring psycopg[binary] 3.2.x
- document psycopg[binary] compatibility for Python 3.13

## Testing
- `python -m pip install -e backend`
- `ruff check backend`
- `mypy backend/app`
- `PYTHONPATH=backend pytest -q --cov=backend/app`
- `bash tools/smoke_ci.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad130e4a648330b9999204991c4c3c