### PR TITLE
CI: installer pytest-cov et publier coverage.xml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install -e backend
-          python -m pip install ruff mypy pytest
+          python -m pip install ruff mypy pytest pytest-cov
       - name: Lint (ruff)
         run: ruff check backend
       - name: Types (mypy)
@@ -24,7 +24,13 @@ jobs:
       - name: Tests (pytest + coverage)
         env:
           PYTHONPATH: backend
-        run: pytest -q --cov=backend/app
+        run: |
+          pytest -q --cov=backend/app --cov-report=xml:coverage.xml
+      - name: Upload coverage.xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-coverage-xml
+          path: coverage.xml
       - name: Smoke (HTTP)
         env:
           API_BASE: http://127.0.0.1:8000

--- a/README.md
+++ b/README.md
@@ -33,8 +33,18 @@ pwsh PS1/seed.ps1
 ### Tests (backend)
 
 ```
-pwsh PS1/test_all.ps1
+pwsh -NoLogo -NoProfile -File PS1/test_all.ps1
 ```
+
+## Coverage (Python)
+
+* Le job CI installe `pytest-cov` et genere `coverage.xml`:
+
+  * `pytest -q --cov=backend/app --cov-report=xml:coverage.xml`
+* Artefact CI: `python-coverage-xml`.
+* Local Windows:
+
+  * `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`
 
 Endpoints clefs:
 


### PR DESCRIPTION
## Summary
- install pytest-cov in Python workflow and generate coverage.xml
- add PowerShell test script installing pytest-cov
- document coverage generation in README

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`
- `bash tools/smoke_ci.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ad14f7d5e08330ad9241dc13b05b81